### PR TITLE
Default size/color selections and newest-first product sort

### DIFF
--- a/app/lib/catalog.ts
+++ b/app/lib/catalog.ts
@@ -152,9 +152,20 @@ function loadProducts(): Product[] {
   return catalogData.products.edges.map(({ node }: any) => node as Product);
 }
 
-// Get all products
+// Extract the trailing numeric identifier from a Shopify GID
+// (e.g. "gid://shopify/Product/8755818758363" -> 8755818758363).
+// Newer products in Shopify receive larger numeric IDs, so sorting
+// by this value in descending order yields newest-first ordering.
+function getNumericProductId(id: string): number {
+  const match = id.match(/(\d+)(?!.*\d)/);
+  return match ? Number(match[1]) : 0;
+}
+
+// Get all products (sorted by product identifier, newest first)
 export function getAllProducts(): SimpleProduct[] {
-  const products = loadProducts();
+  const products = [...loadProducts()].sort(
+    (a, b) => getNumericProductId(b.id) - getNumericProductId(a.id)
+  );
 
   return products.map((product) => ({
     id: product.id,

--- a/app/products/[handle]/ProductPageClient.tsx
+++ b/app/products/[handle]/ProductPageClient.tsx
@@ -92,6 +92,16 @@ export function ColorSelector({
 }) {
   const [selectedColor, setSelectedColor] = useState<string | null>(null);
 
+  // Set a default color when the component mounts
+  useEffect(() => {
+    if (colors.length > 0 && !selectedColor) {
+      const defaultColor =
+        colors.find((c) => c.toLowerCase() === 'black') || colors[0];
+      handleColorClick(defaultColor);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [colors]);
+
   const handleColorClick = (color: string) => {
     setSelectedColor(color);
 


### PR DESCRIPTION
Pre-select a default color (Black when available, otherwise the first
option) on the product detail page, mirroring the existing default size
behavior so users can add to cart without manually picking options when
the defaults are appropriate.

Sort products returned by getAllProducts by numeric Shopify product ID
in descending order so the newest items appear first across the category
list views (Shop All, Hats, T-Shirts, Hoodies). Featured product
ordering is unaffected since getFeaturedProducts re-sorts by
featuredOrder.