### PR TITLE
Design refactor: modern e-commerce polish with micro-animations

### DIFF
--- a/app/components/cart/CartButton.tsx
+++ b/app/components/cart/CartButton.tsx
@@ -8,8 +8,8 @@ export default function CartButton() {
   return (
     <button
       onClick={openCart}
-      className="relative flex items-center justify-center rounded-md p-2 hover:bg-secondary-light"
-      aria-label="Open cart"
+      className="group relative flex items-center justify-center rounded-lg p-2 transition-all duration-200 hover:bg-secondary-light active:scale-90"
+      aria-label={`Open cart${totalItems > 0 ? ` (${totalItems} items)` : ''}`}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -21,14 +21,17 @@ export default function CartButton() {
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
-        className="h-5 w-5"
+        className="h-5 w-5 transition-transform duration-200 group-hover:-translate-y-0.5"
       >
         <circle cx="8" cy="21" r="1" />
         <circle cx="19" cy="21" r="1" />
         <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
       </svg>
       {totalItems > 0 && (
-        <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-medium text-light">
+        <span
+          key={totalItems}
+          className="absolute -right-1 -top-1 flex h-5 w-5 animate-badge-pop items-center justify-center rounded-full bg-maroon text-xs font-bold text-bone shadow-sm"
+        >
           {totalItems}
         </span>
       )}

--- a/app/components/cart/CartDrawer.tsx
+++ b/app/components/cart/CartDrawer.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useCart } from './CartProvider';
 
@@ -157,6 +158,14 @@ export default function CartDrawer() {
             >
               Continue Shopping
             </button>
+            <Link
+              href="/game"
+              onClick={closeCart}
+              className="mt-4 text-xs text-dark-light transition-colors duration-150 hover:text-maroon"
+            >
+              …or beat <span className="font-semibold">Run, Human, Run!</span>{' '}
+              for 25% off →
+            </Link>
           </div>
         ) : (
           <>

--- a/app/components/cart/CartDrawer.tsx
+++ b/app/components/cart/CartDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import { useCart } from './CartProvider';
@@ -9,10 +9,11 @@ export default function CartDrawer() {
   const { cart, isOpen, closeCart, removeFromCart, updateQuantity, subtotal } = useCart();
   const pathname = usePathname();
   const drawerRef = useRef<HTMLDivElement>(null);
-  
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
+
   const isMonthlyDeals = pathname?.startsWith('/monthly-deals');
 
-  // Handle click outside to close
+  // Handle click outside and Escape key to close
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (drawerRef.current && !drawerRef.current.contains(event.target as Node)) {
@@ -20,12 +21,20 @@ export default function CartDrawer() {
       }
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeCart();
+      }
+    };
+
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen, closeCart]);
 
@@ -43,7 +52,9 @@ export default function CartDrawer() {
   }, [isOpen]);
 
   const handleCheckout = async () => {
-    if (cart.length === 0) return;
+    if (cart.length === 0 || isCheckingOut) return;
+
+    setIsCheckingOut(true);
 
     try {
       // Use Stripe checkout for all products
@@ -76,22 +87,26 @@ export default function CartDrawer() {
     } catch (error) {
       console.error('Error creating checkout:', error);
       alert('There was an error processing your order. Please try again.');
+      setIsCheckingOut(false);
     }
   };
 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-dark/50">
+    <div className="fixed inset-0 z-50 animate-fade-in bg-dark/60 backdrop-blur-sm">
       <div
         ref={drawerRef}
-        className="fixed right-0 top-0 h-full w-full max-w-md bg-light p-6 shadow-xl transition-transform sm:w-96"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Shopping cart"
+        className="fixed right-0 top-0 flex h-full w-full max-w-md animate-slide-in-right flex-col bg-light p-6 shadow-drawer sm:w-96"
       >
-        <div className="flex items-center justify-between border-b border-secondary pb-2">
-          <h2 className="text-lg font-bold">Your Cart</h2>
+        <div className="flex items-center justify-between border-b border-dark/10 pb-3">
+          <h2 className="font-bebas-neue text-2xl tracking-wide">Your Cart</h2>
           <button
             onClick={closeCart}
-            className="rounded-md p-1 hover:bg-secondary-light"
+            className="rounded-lg p-1.5 transition-all duration-200 hover:rotate-90 hover:bg-secondary-light active:scale-90"
             aria-label="Close cart"
           >
             <svg
@@ -113,67 +128,79 @@ export default function CartDrawer() {
         </div>
 
         {cart.length === 0 ? (
-          <div className="flex h-[calc(100vh-180px)] flex-col items-center justify-center">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-10 w-10 text-secondary-dark mb-3"
-            >
-              <circle cx="8" cy="21" r="1" />
-              <circle cx="19" cy="21" r="1" />
-              <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
-            </svg>
-            <p className="text-base font-medium">Your cart is empty</p>
+          <div className="flex flex-1 flex-col items-center justify-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary-light">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-8 w-8 text-dark-light"
+              >
+                <circle cx="8" cy="21" r="1" />
+                <circle cx="19" cy="21" r="1" />
+                <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
+              </svg>
+            </div>
+            <p className="mt-4 text-base font-semibold">Your cart is empty</p>
+            <p className="mt-1 text-sm text-dark-light">
+              Fill it with some AI nerdwear.
+            </p>
             <button
               onClick={closeCart}
-              className="mt-3 btn btn-primary text-sm py-2 px-4"
+              className="btn btn-primary mt-5"
             >
               Continue Shopping
             </button>
           </div>
         ) : (
           <>
-            <div className="max-h-[calc(100vh-200px)] overflow-y-auto py-4">
+            <div className="flex-1 overflow-y-auto py-4">
               {cart.map((item) => (
-                <div key={item.id} className="flex border-b border-secondary py-2 text-sm">
-                  <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-md">
+                <div
+                  key={item.id}
+                  className="flex animate-fade-up border-b border-dark/10 py-3 text-sm"
+                >
+                  <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-lg border border-dark/10 bg-secondary-light">
                     <Image
                       src={item.image || '/product-placeholder.jpg'}
                       alt={item.title}
                       fill
                       className="object-cover"
-                      sizes="(max-width: 768px) 12vw, 10vw"
+                      sizes="(max-width: 768px) 16vw, 10vw"
                     />
                   </div>
-                  <div className="ml-2 flex flex-1 flex-col">
-                    <div className="flex justify-between text-sm font-medium">
-                      <h3 className="text-sm truncate max-w-[150px]">{item.title}</h3>
-                      <p className="ml-2 text-sm">${item.price.toFixed(2)}</p>
+                  <div className="ml-3 flex flex-1 flex-col">
+                    <div className="flex justify-between font-medium">
+                      <h3 className="truncate max-w-[170px] text-sm">{item.title}</h3>
+                      <p className="ml-2 font-space-grotesk text-sm font-semibold">
+                        ${item.price.toFixed(2)}
+                      </p>
                     </div>
-                    <div className="flex text-xs text-gray-500 gap-2">
+                    <div className="mt-0.5 flex gap-2 text-xs text-dark-light">
                       {item.size && <span>Size: {item.size}</span>}
                       {item.color && <span>Color: {item.color}</span>}
                     </div>
-                    <div className="mt-1 flex items-center justify-between">
-                      <div className="flex items-center border border-secondary rounded-md">
+                    <div className="mt-2 flex items-center justify-between">
+                      <div className="flex items-center rounded-lg border border-dark/15 bg-white">
                         <button
                           onClick={() => updateQuantity(item.id, item.quantity - 1)}
-                          className="px-1 text-xs hover:bg-secondary-light"
+                          className="px-2 py-1 text-xs font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90"
                           aria-label="Decrease quantity"
                         >
-                          -
+                          −
                         </button>
-                        <span className="px-1 text-xs">{item.quantity}</span>
+                        <span className="min-w-[1.75rem] px-1 py-1 text-center text-xs font-semibold tabular-nums">
+                          {item.quantity}
+                        </span>
                         <button
                           onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                          className="px-1 text-xs hover:bg-secondary-light"
+                          className="px-2 py-1 text-xs font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90"
                           aria-label="Increase quantity"
                         >
                           +
@@ -181,7 +208,7 @@ export default function CartDrawer() {
                       </div>
                       <button
                         onClick={() => removeFromCart(item.id)}
-                        className="text-xs text-primary hover:text-primary-dark"
+                        className="text-xs font-medium text-maroon underline-offset-2 transition-colors duration-150 hover:text-maroon-dark hover:underline"
                       >
                         Remove
                       </button>
@@ -190,26 +217,53 @@ export default function CartDrawer() {
                 </div>
               ))}
             </div>
-            <div className="border-t border-secondary pt-3">
-              <div className="flex justify-between text-sm font-medium">
+            <div className="border-t border-dark/10 pt-4">
+              <div className="flex justify-between font-space-grotesk text-base font-semibold">
                 <p>Subtotal</p>
                 <p>${subtotal.toFixed(2)}</p>
               </div>
-              <p className="mt-1 text-xs text-gray-500">
+              <p className="mt-1 text-xs text-dark-light">
                 Shipping and taxes calculated at checkout.
               </p>
-              <div className="mt-3">
+              <div className="mt-4">
                 <button
                   onClick={handleCheckout}
-                  className="w-full btn btn-primary text-sm py-2"
+                  disabled={isCheckingOut}
+                  className="btn btn-primary w-full py-3 text-base"
                 >
-                  Checkout
+                  {isCheckingOut ? (
+                    <span className="inline-flex items-center gap-2">
+                      <svg
+                        className="h-4 w-4 animate-spin"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 0 1 8-8v4a4 4 0 0 0-4 4H4z"
+                        />
+                      </svg>
+                      Redirecting…
+                    </span>
+                  ) : (
+                    'Checkout'
+                  )}
                 </button>
               </div>
-              <div className="mt-2 flex justify-center text-xs">
+              <div className="mt-3 flex justify-center text-xs">
                 <button
                   onClick={closeCart}
-                  className="text-primary hover:text-primary-dark"
+                  className="font-medium text-maroon underline-offset-2 transition-colors duration-150 hover:text-maroon-dark hover:underline"
                 >
                   Continue Shopping
                 </button>

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -3,25 +3,34 @@
 import Link from "next/link";
 import { FaYoutube, FaSpotify, FaGithub, FaSoundcloud } from 'react-icons/fa';
 
+const footerLinkClass =
+  "group inline-flex items-center text-sm text-bone/70 transition-all duration-200 hover:text-bone hover:translate-x-1";
+
 export default function Footer() {
   return (
-    <footer className="border-t border-secondary bg-light">
-      <div className="container py-8 md:py-12">
+    <footer className="border-t-4 border-maroon bg-charcoal-dark text-bone">
+      <div className="container py-10 md:py-14">
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
           <div>
-            <h3 className="text-lg font-bold">A-OK Store</h3>
-            <p className="mt-2 text-sm">Nerd streetwear for AI junkies</p>
+            <h3 className="font-bebas-neue text-2xl tracking-wide text-bone">
+              A-OK Store
+            </h3>
+            <p className="mt-2 text-sm text-bone/70">
+              Nerd streetwear for AI junkies
+            </p>
           </div>
           <div>
-            <h3 className="text-lg font-bold">Quick Links</h3>
-            <ul className="mt-2 space-y-2">
+            <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-bone/50">
+              Quick Links
+            </h3>
+            <ul className="mt-3 space-y-2">
               <li>
-                <Link href="/" className="text-sm hover:text-primary">
+                <Link href="/" className={footerLinkClass}>
                   Home
                 </Link>
               </li>
               <li>
-                <Link href="/products" className="text-sm hover:text-primary">
+                <Link href="/products" className={footerLinkClass}>
                   Shop
                 </Link>
               </li>
@@ -29,7 +38,7 @@ export default function Footer() {
                 <Link
                   href="https://apesonkeys.com"
                   target="_blank"
-                  className="text-sm hover:text-primary"
+                  className={footerLinkClass}
                 >
                   About
                 </Link>
@@ -37,14 +46,16 @@ export default function Footer() {
             </ul>
           </div>
           <div>
-            <h3 className="text-lg font-bold">Contact</h3>
-            <ul className="mt-2 space-y-2">
-              <li className="text-sm">Email: info @ a-ok.shop</li>
+            <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-bone/50">
+              Contact
+            </h3>
+            <ul className="mt-3 space-y-2">
+              <li className="text-sm text-bone/70">Email: info @ a-ok.shop</li>
               <li>
                 <Link
                   href="https://x.com/apesonkeys"
                   target="_blank"
-                  className="text-sm hover:text-primary"
+                  className={footerLinkClass}
                 >
                   Find us on X
                 </Link>
@@ -52,49 +63,55 @@ export default function Footer() {
             </ul>
           </div>
           <div>
-            <h3 className="text-lg font-bold">Follow Us</h3>
-            <ul className="mt-2 space-y-2">
+            <h3 className="text-xs font-bold uppercase tracking-[0.2em] text-bone/50">
+              Follow Us
+            </h3>
+            <ul className="mt-3 space-y-2">
               <li>
                 <Link
                   href="https://www.youtube.com/@apesonkeys/videos"
                   target="_blank"
-                  className="text-sm hover:text-primary flex items-center"
+                  className={footerLinkClass}
                 >
-                  <FaYoutube className="mr-2 h-5 w-5" /> APES ON KNOWLEDGE
+                  <FaYoutube className="mr-2 h-5 w-5 transition-colors duration-200 group-hover:text-[#FF0000]" />
+                  APES ON KNOWLEDGE
                 </Link>
               </li>
               <li>
                 <Link
                   href="https://open.spotify.com/show/5mzflcTu9vWhB0Nw0lABRo"
                   target="_blank"
-                  className="text-sm hover:text-primary flex items-center"
+                  className={footerLinkClass}
                 >
-                  <FaSpotify className="mr-2 h-5 w-5" /> Key To Sleep
+                  <FaSpotify className="mr-2 h-5 w-5 transition-colors duration-200 group-hover:text-[#1DB954]" />
+                  Key To Sleep
                 </Link>
               </li>
               <li>
                 <Link
                   href="https://github.com/lucasdickey/a-ok-shop"
                   target="_blank"
-                  className="text-sm hover:text-primary flex items-center"
+                  className={footerLinkClass}
                 >
-                  <FaGithub className="mr-2 h-5 w-5" /> Go ape our shit
+                  <FaGithub className="mr-2 h-5 w-5 transition-colors duration-200 group-hover:text-white" />
+                  Go ape our shit
                 </Link>
               </li>
               <li>
                 <Link
                   href="https://soundcloud.com/lucasdickey"
                   target="_blank"
-                  className="text-sm hover:text-primary flex items-center"
+                  className={footerLinkClass}
                 >
-                  <FaSoundcloud className="mr-2 h-5 w-5" /> Music To Vibe To
+                  <FaSoundcloud className="mr-2 h-5 w-5 transition-colors duration-200 group-hover:text-[#FF5500]" />
+                  Music To Vibe To
                 </Link>
               </li>
             </ul>
           </div>
         </div>
-        <div className="mt-8 border-t border-secondary pt-8 text-center">
-          <p className="text-sm">
+        <div className="mt-10 border-t border-bone/10 pt-6 text-center">
+          <p className="text-sm text-bone/50">
             &copy; {new Date().getFullYear()} A-OK Store. All rights reserved.
           </p>
         </div>

--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
   return (
     <footer className="border-t-4 border-maroon bg-charcoal-dark text-bone">
       <div className="container py-10 md:py-14">
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
           <div>
             <h3 className="font-bebas-neue text-2xl tracking-wide text-bone">
               A-OK Store

--- a/app/components/layout/Navbar.tsx
+++ b/app/components/layout/Navbar.tsx
@@ -1,39 +1,32 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import CartButton from "../cart/CartButton";
 import TextAnimatedLogo from "./TextAnimatedLogo";
 
 export default function Navbar() {
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-secondary bg-light/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-40 w-full border-b border-dark/10 bg-light/80 shadow-sm backdrop-blur-md">
       <div className="container flex h-16 items-center justify-between">
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-8">
           <TextAnimatedLogo />
-          <nav className="hidden md:flex gap-6">
-            <Link
-              href="/products?category=t-shirts"
-              className="text-sm font-medium hover:text-primary"
-            >
+          <nav className="hidden items-center gap-6 md:flex">
+            <Link href="/products?category=t-shirts" className="nav-link">
               T-Shirts
             </Link>
-            <Link
-              href="/products?category=hoodies"
-              className="text-sm font-medium hover:text-primary"
-            >
+            <Link href="/products?category=hoodies" className="nav-link">
               Hoodies
             </Link>
-            <Link
-              href="/products?category=hats"
-              className="text-sm font-medium hover:text-primary"
-            >
+            <Link href="/products?category=hats" className="nav-link">
               Hats
             </Link>
-            <span className="text-sm text-gray-400">|</span>
+            <span
+              aria-hidden="true"
+              className="h-4 w-px bg-dark/20"
+            />
             <Link
               href="/game"
-              className="text-sm font-medium hover:text-primary animate-pulse"
+              className="nav-link text-maroon after:bg-charcoal-dark hover:text-charcoal-dark"
             >
               Run, Human, Run!
             </Link>

--- a/app/components/layout/Navbar.tsx
+++ b/app/components/layout/Navbar.tsx
@@ -1,29 +1,33 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import CartButton from "../cart/CartButton";
 import TextAnimatedLogo from "./TextAnimatedLogo";
 
+const navLinks = [
+  { label: "T-Shirts", href: "/products?category=t-shirts" },
+  { label: "Hoodies", href: "/products?category=hoodies" },
+  { label: "Hats", href: "/products?category=hats" },
+];
+
 export default function Navbar() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const closeMenu = () => setMenuOpen(false);
+
   return (
     <header className="sticky top-0 z-40 w-full border-b border-dark/10 bg-light/80 shadow-sm backdrop-blur-md">
       <div className="container flex h-16 items-center justify-between">
         <div className="flex items-center gap-8">
           <TextAnimatedLogo />
           <nav className="hidden items-center gap-6 md:flex">
-            <Link href="/products?category=t-shirts" className="nav-link">
-              T-Shirts
-            </Link>
-            <Link href="/products?category=hoodies" className="nav-link">
-              Hoodies
-            </Link>
-            <Link href="/products?category=hats" className="nav-link">
-              Hats
-            </Link>
-            <span
-              aria-hidden="true"
-              className="h-4 w-px bg-dark/20"
-            />
+            {navLinks.map(({ label, href }) => (
+              <Link key={label} href={href} className="nav-link">
+                {label}
+              </Link>
+            ))}
+            <span aria-hidden="true" className="h-4 w-px bg-dark/20" />
             <Link
               href="/game"
               className="nav-link text-maroon after:bg-charcoal-dark hover:text-charcoal-dark"
@@ -32,10 +36,104 @@ export default function Navbar() {
             </Link>
           </nav>
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-1">
           <CartButton />
+          {/* Mobile menu toggle */}
+          <button
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-expanded={menuOpen}
+            aria-controls="mobile-menu"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            className="relative flex h-10 w-10 items-center justify-center rounded-lg transition-colors duration-200 hover:bg-secondary-light active:scale-90 md:hidden"
+          >
+            <span
+              className={`absolute block h-0.5 w-5 rounded-full bg-dark transition-all duration-300 ease-out-expo ${
+                menuOpen ? "rotate-45" : "-translate-y-1.5"
+              }`}
+            />
+            <span
+              className={`absolute block h-0.5 w-5 rounded-full bg-dark transition-all duration-300 ease-out-expo ${
+                menuOpen ? "opacity-0" : "opacity-100"
+              }`}
+            />
+            <span
+              className={`absolute block h-0.5 w-5 rounded-full bg-dark transition-all duration-300 ease-out-expo ${
+                menuOpen ? "-rotate-45" : "translate-y-1.5"
+              }`}
+            />
+          </button>
         </div>
       </div>
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div className="md:hidden">
+          {/* Backdrop below the panel */}
+          <div
+            className="fixed inset-0 top-16 z-40 animate-fade-in bg-dark/40 backdrop-blur-sm"
+            onClick={closeMenu}
+            aria-hidden="true"
+          />
+          <nav
+            id="mobile-menu"
+            aria-label="Mobile navigation"
+            className="absolute inset-x-0 top-16 z-50 border-b border-dark/10 bg-light shadow-card-hover"
+          >
+            <div className="stagger-children container flex flex-col py-3">
+              {navLinks.map(({ label, href }) => (
+                <Link
+                  key={label}
+                  href={href}
+                  onClick={closeMenu}
+                  className="flex items-center justify-between border-b border-dark/5 py-3.5 text-base font-semibold transition-colors duration-150 active:text-maroon"
+                >
+                  {label}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-4 w-4 text-dark/30"
+                  >
+                    <path d="m9 18 6-6-6-6" />
+                  </svg>
+                </Link>
+              ))}
+              <Link
+                href="/products"
+                onClick={closeMenu}
+                className="flex items-center justify-between border-b border-dark/5 py-3.5 text-base font-semibold transition-colors duration-150 active:text-maroon"
+              >
+                Shop All
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4 text-dark/30"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </Link>
+              <Link
+                href="/game"
+                onClick={closeMenu}
+                className="flex items-center justify-between py-3.5 text-base font-semibold text-maroon transition-colors duration-150 active:text-maroon-dark"
+              >
+                Run, Human, Run!
+                <span aria-hidden="true">🎮</span>
+              </Link>
+            </div>
+          </nav>
+        </div>
+      )}
     </header>
   );
 }

--- a/app/components/product/AddToCartButton.tsx
+++ b/app/components/product/AddToCartButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useCart, CartItem } from '@/app/components/cart/CartProvider';
 
 type AddToCartButtonProps = {
@@ -16,19 +16,41 @@ type AddToCartButtonProps = {
   quantity?: number;
   showSizeWarning?: boolean;
   showColorWarning?: boolean;
+  /** Show a fixed bottom add-to-cart bar on mobile when the main button scrolls out of view */
+  stickyOnMobile?: boolean;
 };
 
 export default function AddToCartButton({
   product,
   quantity = 1,
   showSizeWarning = false,
-  showColorWarning = false
+  showColorWarning = false,
+  stickyOnMobile = false
 }: AddToCartButtonProps) {
   const { addToCart } = useCart();
   const [isAdded, setIsAdded] = useState(false);
   const [itemQuantity, setItemQuantity] = useState(quantity);
   const [showWarning, setShowWarning] = useState(false);
   const [warningMessage, setWarningMessage] = useState('');
+  const [showStickyBar, setShowStickyBar] = useState(false);
+  const mainRowRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!stickyOnMobile || !mainRowRef.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        // Only surface the bar once the main CTA has scrolled up out of view
+        setShowStickyBar(
+          !entry.isIntersecting && entry.boundingClientRect.top < 0
+        );
+      },
+      { threshold: 0 }
+    );
+
+    observer.observe(mainRowRef.current);
+    return () => observer.disconnect();
+  }, [stickyOnMobile]);
 
   const handleAddToCart = () => {
     if (showSizeWarning) {
@@ -69,9 +91,30 @@ export default function AddToCartButton({
     }, 1500);
   };
 
+  const addedLabel = (
+    <span className="inline-flex animate-scale-in items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-5 w-5"
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+      Added to Cart
+    </span>
+  );
+
   return (
     <div>
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+      <div
+        ref={mainRowRef}
+        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4"
+      >
         <div className="flex items-center justify-between rounded-lg border-2 border-dark/15 bg-white sm:justify-start">
           <button
             onClick={() => setItemQuantity(prev => Math.max(1, prev - 1))}
@@ -101,31 +144,48 @@ export default function AddToCartButton({
               : 'btn-primary'
           }`}
         >
-          {isAdded ? (
-            <span className="inline-flex animate-scale-in items-center gap-2">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="3"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-5 w-5"
-              >
-                <path d="M20 6 9 17l-5-5" />
-              </svg>
-              Added to Cart
-            </span>
-          ) : (
-            'Add to Cart'
-          )}
+          {isAdded ? addedLabel : 'Add to Cart'}
         </button>
       </div>
 
       {showWarning && (
         <div className="mt-3 animate-fade-up rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
           {warningMessage}
+        </div>
+      )}
+
+      {/* Sticky mobile add-to-cart bar */}
+      {stickyOnMobile && showStickyBar && (
+        <div className="fixed inset-x-0 bottom-0 z-30 animate-fade-up border-t border-dark/10 bg-light/95 px-4 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3 shadow-drawer backdrop-blur-md md:hidden">
+          {showWarning && (
+            <div className="mb-2 rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs font-medium text-red-700">
+              {warningMessage}
+            </div>
+          )}
+          <div className="flex items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold">{product.title}</p>
+              <p className="font-space-grotesk text-base font-semibold text-maroon">
+                ${product.price.toFixed(2)}
+                {itemQuantity > 1 && (
+                  <span className="ml-1 text-xs font-medium text-dark-light">
+                    × {itemQuantity}
+                  </span>
+                )}
+              </p>
+            </div>
+            <button
+              onClick={handleAddToCart}
+              disabled={isAdded}
+              className={`btn px-6 py-2.5 text-sm ${
+                isAdded
+                  ? 'bg-green-700 text-white shadow-md disabled:opacity-100'
+                  : 'btn-primary'
+              }`}
+            >
+              {isAdded ? addedLabel : 'Add to Cart'}
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/app/components/product/AddToCartButton.tsx
+++ b/app/components/product/AddToCartButton.tsx
@@ -18,14 +18,14 @@ type AddToCartButtonProps = {
   showColorWarning?: boolean;
 };
 
-export default function AddToCartButton({ 
-  product, 
-  quantity = 1, 
+export default function AddToCartButton({
+  product,
+  quantity = 1,
   showSizeWarning = false,
-  showColorWarning = false 
+  showColorWarning = false
 }: AddToCartButtonProps) {
   const { addToCart } = useCart();
-  const [isAdding, setIsAdding] = useState(false);
+  const [isAdded, setIsAdded] = useState(false);
   const [itemQuantity, setItemQuantity] = useState(quantity);
   const [showWarning, setShowWarning] = useState(false);
   const [warningMessage, setWarningMessage] = useState('');
@@ -48,9 +48,9 @@ export default function AddToCartButton({
       }, 3000);
       return;
     }
-    
-    setIsAdding(true);
-    
+
+    setIsAdded(true);
+
     const cartItem: CartItem = {
       id: product.id,
       title: product.title,
@@ -61,46 +61,70 @@ export default function AddToCartButton({
       size: product.size,
       color: product.color,
     };
-    
+
     addToCart(cartItem);
-    
+
     setTimeout(() => {
-      setIsAdding(false);
-    }, 1000);
+      setIsAdded(false);
+    }, 1500);
   };
 
   return (
     <div>
       <div className="flex items-center gap-4">
-        <div className="flex items-center border border-secondary rounded-md">
+        <div className="flex items-center rounded-lg border-2 border-dark/15 bg-white">
           <button
             onClick={() => setItemQuantity(prev => Math.max(1, prev - 1))}
-            className="px-3 py-2 hover:bg-secondary-light"
+            className="px-3 py-2 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-l-md"
             aria-label="Decrease quantity"
           >
-            -
+            −
           </button>
-          <span className="px-3 py-2">{itemQuantity}</span>
+          <span className="min-w-[2.5rem] px-2 py-2 text-center font-space-grotesk font-semibold tabular-nums">
+            {itemQuantity}
+          </span>
           <button
             onClick={() => setItemQuantity(prev => prev + 1)}
-            className="px-3 py-2 hover:bg-secondary-light"
+            className="px-3 py-2 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-r-md"
             aria-label="Increase quantity"
           >
             +
           </button>
         </div>
-        
+
         <button
           onClick={handleAddToCart}
-          disabled={isAdding}
-          className="btn btn-primary flex-1"
+          disabled={isAdded}
+          className={`btn flex-1 py-3 text-base ${
+            isAdded
+              ? 'bg-green-700 text-white shadow-md disabled:opacity-100'
+              : 'btn-primary'
+          }`}
         >
-          {isAdding ? 'Adding...' : 'Add to Cart'}
+          {isAdded ? (
+            <span className="inline-flex animate-scale-in items-center gap-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5"
+              >
+                <path d="M20 6 9 17l-5-5" />
+              </svg>
+              Added to Cart
+            </span>
+          ) : (
+            'Add to Cart'
+          )}
         </button>
       </div>
-      
+
       {showWarning && (
-        <div className="mt-2 text-sm text-red-500">
+        <div className="mt-3 animate-fade-up rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm font-medium text-red-700">
           {warningMessage}
         </div>
       )}

--- a/app/components/product/AddToCartButton.tsx
+++ b/app/components/product/AddToCartButton.tsx
@@ -71,11 +71,11 @@ export default function AddToCartButton({
 
   return (
     <div>
-      <div className="flex items-center gap-4">
-        <div className="flex items-center rounded-lg border-2 border-dark/15 bg-white">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex items-center justify-between rounded-lg border-2 border-dark/15 bg-white sm:justify-start">
           <button
             onClick={() => setItemQuantity(prev => Math.max(1, prev - 1))}
-            className="px-3 py-2 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-l-md"
+            className="px-4 py-2.5 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-l-md sm:px-3 sm:py-2"
             aria-label="Decrease quantity"
           >
             −
@@ -85,7 +85,7 @@ export default function AddToCartButton({
           </span>
           <button
             onClick={() => setItemQuantity(prev => prev + 1)}
-            className="px-3 py-2 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-r-md"
+            className="px-4 py-2.5 font-semibold transition-colors duration-150 hover:bg-secondary-light active:scale-90 rounded-r-md sm:px-3 sm:py-2"
             aria-label="Increase quantity"
           >
             +

--- a/app/components/product/ProductCard.tsx
+++ b/app/components/product/ProductCard.tsx
@@ -57,12 +57,12 @@ export default function ProductCard({ product }: ProductCardProps) {
             unoptimized={!imageUrl.startsWith('http')}
           />
           <span
-            className={`absolute left-3 top-3 z-10 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider shadow-sm ${badgeStyles[cardType]}`}
+            className={`absolute left-2 top-2 z-10 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider shadow-sm sm:left-3 sm:top-3 sm:px-3 sm:py-1 sm:text-xs ${badgeStyles[cardType]}`}
           >
             {badgeLabels[cardType]}
           </span>
-          {/* Reveal CTA on hover */}
-          <div className="absolute inset-x-0 bottom-0 z-10 translate-y-full p-3 transition-transform duration-300 ease-out-expo group-hover:translate-y-0">
+          {/* Reveal CTA on hover (desktop only — whole card is the tap target on mobile) */}
+          <div className="absolute inset-x-0 bottom-0 z-10 hidden translate-y-full p-3 transition-transform duration-300 ease-out-expo group-hover:translate-y-0 sm:block">
             <span className="flex w-full items-center justify-center rounded-lg bg-charcoal-dark/90 py-2.5 text-sm font-semibold text-bone backdrop-blur-sm">
               View Product
               <svg
@@ -82,11 +82,11 @@ export default function ProductCard({ product }: ProductCardProps) {
           </div>
         </div>
 
-        <div className="flex flex-1 flex-col justify-between gap-1 p-4">
-          <h3 className="font-space-grotesk text-base font-semibold leading-snug text-dark transition-colors duration-200 group-hover:text-maroon">
+        <div className="flex flex-1 flex-col justify-between gap-1 p-3 sm:p-4">
+          <h3 className="line-clamp-2 font-space-grotesk text-sm font-semibold leading-snug text-dark transition-colors duration-200 group-hover:text-maroon sm:text-base">
             {title}
           </h3>
-          <p className="font-space-grotesk text-lg font-medium text-maroon">
+          <p className="font-space-grotesk text-base font-medium text-maroon sm:text-lg">
             ${price.toFixed(2)}
           </p>
         </div>

--- a/app/components/product/ProductCard.tsx
+++ b/app/components/product/ProductCard.tsx
@@ -56,8 +56,9 @@ export default function ProductCard({ product }: ProductCardProps) {
             className="object-cover transition-transform duration-500 ease-out-expo group-hover:scale-105"
             unoptimized={!imageUrl.startsWith('http')}
           />
+          <span aria-hidden="true" className="shine" />
           <span
-            className={`absolute left-2 top-2 z-10 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider shadow-sm sm:left-3 sm:top-3 sm:px-3 sm:py-1 sm:text-xs ${badgeStyles[cardType]}`}
+            className={`absolute left-2 top-2 z-10 -rotate-2 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider shadow-sm transition-transform duration-200 group-hover:rotate-0 sm:left-3 sm:top-3 sm:px-3 sm:py-1 sm:text-xs ${badgeStyles[cardType]}`}
           >
             {badgeLabels[cardType]}
           </span>

--- a/app/components/product/ProductCard.tsx
+++ b/app/components/product/ProductCard.tsx
@@ -8,207 +8,89 @@ type ProductCardProps = {
   product: ShopifyProduct;
 };
 
+type CardType = 't-shirt' | 'hoodie' | 'hat';
+
+function getCardType(productType: string, tags: string[]): CardType {
+  const type = productType.toLowerCase();
+  const hasTag = (needle: string) =>
+    tags.some((tag) => tag.toLowerCase().includes(needle));
+
+  if (type.includes('hoodie') || hasTag('hoodie')) return 'hoodie';
+  if (type.includes('hat') || hasTag('hat')) return 'hat';
+  return 't-shirt';
+}
+
+const badgeStyles: Record<CardType, string> = {
+  't-shirt': 'bg-charcoal-dark text-bone',
+  hoodie: 'bg-bone text-charcoal-dark border border-charcoal-dark/20',
+  hat: 'bg-maroon text-bone',
+};
+
+const badgeLabels: Record<CardType, string> = {
+  't-shirt': 'Tee',
+  hoodie: 'Hoodie',
+  hat: 'Hat',
+};
+
 export default function ProductCard({ product }: ProductCardProps) {
-  const { handle, title, priceRange, images, options, variants, productType, tags } = product;
-  
+  const { handle, title, priceRange, images, productType, tags } = product;
+
   const price = parseFloat(priceRange.minVariantPrice.amount);
   const imageUrl = images.edges[0]?.node.url || '/images/product-placeholder.jpg';
   const imageAlt = images.edges[0]?.node.altText || title;
-  
-  // Determine product type for styling
-  let cardType = '';
-  let bgColor = '';
-  let textColor = 'white';
-  let priceColor = '#FCEFB9'; // Default yellow highlight
-  let sizeBgColor = 'rgba(255, 255, 255, 0.1)';
-  let sizeBorderColor = '#F5F2DC';
-  let sizeTextColor = 'white';
-  
-  if (productType.toLowerCase().includes('hoodie') || tags.some(tag => tag.toLowerCase().includes('hoodie'))) {
-    cardType = 'hoodie';
-    bgColor = '#F5F2DC'; // Bone White
-    textColor = '#1F1F1F';
-    priceColor = '#8B1E24';
-    sizeBgColor = 'rgba(0, 0, 0, 0.1)';
-    sizeBorderColor = '#1F1F1F';
-    sizeTextColor = '#1F1F1F';
-  } else if (productType.toLowerCase().includes('hat') || tags.some(tag => tag.toLowerCase().includes('hat'))) {
-    cardType = 'hat';
-    bgColor = '#8B1E24'; // Dark Maroon for hats
-  } else {
-    // Default to t-shirt
-    cardType = 't-shirt';
-    bgColor = '#2C2C2C'; // Black for t-shirts
-  }
-  
-  // Extract size information - include all standard clothing sizes
-  const standardSizes = ['2XS', 'XS', 'S', 'M', 'L', 'XL', '2XL', '3XL'];
-  let sizeValues: string[] = [];
-  
-  // Track availability for each size
-  const sizeAvailability: Record<string, boolean> = {};
-  standardSizes.forEach(size => {
-    sizeAvailability[size] = false; // Default to unavailable
-  });
-  
-  // First try to get size options from the product options
-  const sizeOption = options?.find(option => 
-    option.name.toLowerCase() === 'size'
-  );
-  
-  if (sizeOption && sizeOption.values.length > 0) {
-    // Filter to only include standard sizes
-    sizeValues = sizeOption.values.filter(size => standardSizes.includes(size));
-    
-    // Update size availability
-    sizeValues.forEach(size => {
-      sizeAvailability[size] = true;
-    });
-  }
-  
-  // If no size options found, try to extract from variants
-  if (sizeValues.length === 0 && variants?.edges) {
-    const sizeSet = new Set<string>();
-    
-    variants.edges.forEach(({ node }) => {
-      if (node.selectedOptions) {
-        const sizeOption = node.selectedOptions.find((opt: any) => 
-          opt.name.toLowerCase() === 'size'
-        );
-        
-        if (sizeOption && standardSizes.includes(sizeOption.value)) {
-          sizeSet.add(sizeOption.value);
-          sizeAvailability[sizeOption.value] = node.availableForSale;
-        } else if (standardSizes.includes(node.title)) {
-          // If variant title is a standard size
-          sizeSet.add(node.title);
-          sizeAvailability[node.title] = node.availableForSale;
-        }
-      }
-    });
-    
-    sizeValues = Array.from(sizeSet);
-  }
-  
-  // If still no size values and this is a clothing item, use all standard sizes as a fallback
-  // But mark them as unavailable unless we have specific availability information
-  if ((cardType === 't-shirt' || cardType === 'hoodie') && sizeValues.length === 0) {
-    sizeValues = [...standardSizes];
-  }
-  
-  // Sort sizes in the standard order
-  sizeValues.sort((a, b) => {
-    return standardSizes.indexOf(a) - standardSizes.indexOf(b);
-  });
-  
-  const hasSizes = sizeValues.length > 0;
-
-  // Card styles
-  const cardStyle = {
-    backgroundColor: bgColor,
-    color: textColor,
-    border: '2px solid #1F1F1F',
-    borderRadius: '12px',
-    padding: '1.25rem 1rem',
-    display: 'flex',
-    flexDirection: 'column' as 'column',
-    justifyContent: 'space-between',
-    transition: 'transform 0.2s ease, box-shadow 0.2s ease',
-    fontFamily: "'Space Grotesk', sans-serif",
-    height: '100%',
-    cursor: 'pointer',
-    maxWidth: '100%'
-  };
-
-  const titleStyle = {
-    fontSize: '1rem',
-    fontWeight: 600,
-    lineHeight: 1.3,
-    marginBottom: '0.5rem',
-    color: textColor,
-    fontFamily: "'Space Grotesk', sans-serif",
-    letterSpacing: '0.01em'
-  };
-
-  const priceStyle = {
-    fontSize: '1.25rem',
-    fontWeight: 500,
-    color: priceColor,
-    marginBottom: '1rem',
-    fontFamily: "'Space Grotesk', sans-serif",
-    letterSpacing: '0.02em'
-  };
-
-  const sizeOptionsStyle = {
-    display: 'flex',
-    gap: '0.5rem',
-    marginTop: 'auto',
-    flexWrap: 'wrap' as 'wrap'
-  };
-
-  const sizeButtonStyle = {
-    backgroundColor: sizeBgColor,
-    border: `1px solid ${sizeBorderColor}`,
-    color: sizeTextColor,
-    padding: '0.25rem 0.6rem',
-    borderRadius: '50px',
-    fontSize: '0.75rem',
-    cursor: 'pointer',
-    transition: 'border-color 0.2s ease, background-color 0.2s ease, font-weight 0.2s ease',
-    fontFamily: "'Space Grotesk', sans-serif",
-    minWidth: '2rem',
-    textAlign: 'center' as 'center'
-  };
-
-  const imageContainerStyle = {
-    position: 'relative' as 'relative',
-    aspectRatio: '1/1' as '1/1',
-    overflow: 'hidden',
-    borderRadius: '8px',
-    border: '1px solid #1F1F1F',
-    marginBottom: '1rem',
-    width: '100%',
-    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-    backgroundColor: '#f8f8f8'
-  };
+  const cardType = getCardType(productType, tags);
 
   return (
-    <Link 
-      href={`/products/${handle}`} 
+    <Link
+      href={`/products/${handle}`}
       aria-label={`View ${title} details`}
-      style={{
-        textDecoration: 'none',
-        color: 'inherit'
-      }}
+      className="group block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-maroon focus-visible:ring-offset-2 rounded-2xl"
     >
-      <div 
-        style={cardStyle}
-      >
-        <div style={imageContainerStyle} className="image-container-hover">
+      <article className="card card-hover flex h-full flex-col">
+        <div className="relative aspect-square w-full overflow-hidden bg-light-dark">
           <Image
             src={imageUrl}
             alt={imageAlt}
             fill
-            style={{
-              objectFit: 'cover',
-              transition: 'transform 0.3s ease'
-            }}
-            className="product-image-hover"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+            className="object-cover transition-transform duration-500 ease-out-expo group-hover:scale-105"
             unoptimized={!imageUrl.startsWith('http')}
           />
+          <span
+            className={`absolute left-3 top-3 z-10 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider shadow-sm ${badgeStyles[cardType]}`}
+          >
+            {badgeLabels[cardType]}
+          </span>
+          {/* Reveal CTA on hover */}
+          <div className="absolute inset-x-0 bottom-0 z-10 translate-y-full p-3 transition-transform duration-300 ease-out-expo group-hover:translate-y-0">
+            <span className="flex w-full items-center justify-center rounded-lg bg-charcoal-dark/90 py-2.5 text-sm font-semibold text-bone backdrop-blur-sm">
+              View Product
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="ml-2 h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5"
+              >
+                <path d="M5 12h14" />
+                <path d="m12 5 7 7-7 7" />
+              </svg>
+            </span>
+          </div>
         </div>
-        
-        <div style={{
-          display: 'flex',
-          flexDirection: 'column',
-          flexGrow: 1
-        }}>
-          <h3 style={titleStyle}>{title}</h3>
-          <p style={priceStyle}>${price.toFixed(2)}</p>
-          
-          {/* Size options removed from product list view */}
+
+        <div className="flex flex-1 flex-col justify-between gap-1 p-4">
+          <h3 className="font-space-grotesk text-base font-semibold leading-snug text-dark transition-colors duration-200 group-hover:text-maroon">
+            {title}
+          </h3>
+          <p className="font-space-grotesk text-lg font-medium text-maroon">
+            ${price.toFixed(2)}
+          </p>
         </div>
-      </div>
+      </article>
     </Link>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -131,6 +131,37 @@
     @apply mb-2 inline-block text-xs font-bold uppercase tracking-[0.2em] text-maroon;
   }
 
+  /* Brand ticker marquee */
+  .marquee {
+    @apply overflow-hidden whitespace-nowrap;
+  }
+
+  .marquee-track {
+    display: flex;
+    width: max-content;
+    animation: marquee 28s linear infinite;
+  }
+
+  .marquee:hover .marquee-track {
+    animation-play-state: paused;
+  }
+
+  /* Diagonal shine sweep on hover (pair with a `group` parent) */
+  .shine {
+    @apply pointer-events-none absolute inset-0 z-10;
+    background: linear-gradient(
+      105deg,
+      transparent 40%,
+      rgba(255, 255, 255, 0.35) 50%,
+      transparent 60%
+    );
+    transform: translateX(-101%);
+  }
+
+  .group:hover .shine {
+    animation: shine-sweep 0.75s ease-out;
+  }
+
   /* Staggered entrance for grid children */
   .stagger-children > * {
     animation: fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
@@ -372,6 +403,18 @@
       padding-left: 0;
       padding-right: 0;
     }
+  }
+}
+
+@keyframes marquee {
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes shine-sweep {
+  to {
+    transform: translateX(101%);
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,8 +9,28 @@
 }
 
 @layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
     @apply bg-light text-dark antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    @apply bg-maroon text-bone;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
   }
 
   .bebas-heading {
@@ -45,20 +65,76 @@
 
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none;
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold tracking-wide transition-all duration-200 ease-out-expo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none active:scale-[0.97];
   }
   .btn-primary {
-    @apply bg-primary text-light hover:bg-primary-dark;
+    @apply bg-maroon text-bone shadow-sm hover:bg-maroon-dark hover:shadow-md hover:-translate-y-0.5;
   }
   .btn-secondary {
-    @apply bg-secondary text-dark hover:bg-secondary-dark;
+    @apply bg-secondary text-dark shadow-sm hover:bg-secondary-dark hover:shadow-md hover:-translate-y-0.5;
   }
   .btn-outline {
-    @apply border border-dark bg-transparent hover:bg-secondary-light;
+    @apply border-2 border-dark bg-transparent hover:bg-dark hover:text-light hover:-translate-y-0.5 hover:shadow-md;
+  }
+  .btn-dark {
+    @apply bg-charcoal-dark text-bone shadow-sm hover:bg-dark hover:shadow-md hover:-translate-y-0.5;
   }
   .container {
     @apply mx-auto px-4 md:px-6 lg:px-8;
   }
+
+  /* Animated underline for nav links */
+  .nav-link {
+    @apply relative text-sm font-medium text-dark transition-colors duration-200 hover:text-maroon;
+  }
+
+  .nav-link::after {
+    content: "";
+    @apply absolute -bottom-1 left-0 h-0.5 w-full origin-left scale-x-0 bg-maroon transition-transform duration-300 ease-out-expo;
+  }
+
+  .nav-link:hover::after,
+  .nav-link:focus-visible::after {
+    @apply scale-x-100;
+  }
+
+  /* Category filter chips */
+  .chip {
+    @apply inline-flex items-center rounded-full border-2 border-charcoal-dark bg-transparent px-4 py-1.5 text-sm font-semibold transition-all duration-200 ease-out-expo hover:-translate-y-0.5 hover:bg-charcoal-dark hover:text-bone hover:shadow-md active:scale-95;
+  }
+
+  .chip-active {
+    @apply bg-charcoal-dark text-bone shadow-sm;
+  }
+
+  /* Modern product card */
+  .card {
+    @apply overflow-hidden rounded-2xl border border-dark/10 bg-white shadow-card transition-all duration-300 ease-out-expo;
+  }
+
+  .card-hover {
+    @apply hover:-translate-y-1 hover:shadow-card-hover hover:border-dark/20;
+  }
+
+  /* Section eyebrow + heading pattern */
+  .section-eyebrow {
+    @apply mb-2 inline-block text-xs font-bold uppercase tracking-[0.2em] text-maroon;
+  }
+
+  /* Staggered entrance for grid children */
+  .stagger-children > * {
+    animation: fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .stagger-children > *:nth-child(1) { animation-delay: 0ms; }
+  .stagger-children > *:nth-child(2) { animation-delay: 60ms; }
+  .stagger-children > *:nth-child(3) { animation-delay: 120ms; }
+  .stagger-children > *:nth-child(4) { animation-delay: 180ms; }
+  .stagger-children > *:nth-child(5) { animation-delay: 240ms; }
+  .stagger-children > *:nth-child(6) { animation-delay: 300ms; }
+  .stagger-children > *:nth-child(7) { animation-delay: 360ms; }
+  .stagger-children > *:nth-child(8) { animation-delay: 420ms; }
+  .stagger-children > *:nth-child(n + 9) { animation-delay: 480ms; }
 
   /* Product description formatting */
   .product-description {
@@ -286,6 +362,18 @@
       padding-left: 0;
       padding-right: 0;
     }
+  }
+}
+
+/* Keyframes shared with Tailwind's animate-* utilities (kept in sync with tailwind.config.js) */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -98,6 +98,16 @@
     @apply scale-x-100;
   }
 
+  /* Hide scrollbars on horizontal scroll rows (mobile chip rails etc.) */
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
   /* Category filter chips */
   .chip {
     @apply inline-flex items-center rounded-full border-2 border-charcoal-dark bg-transparent px-4 py-1.5 text-sm font-semibold transition-all duration-200 ease-out-expo hover:-translate-y-0.5 hover:bg-charcoal-dark hover:text-bone hover:shadow-md active:scale-95;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,10 +88,10 @@ export default async function Home() {
   const galleryImages = await getGalleryImages();
 
   return (
-    <div className="container mx-auto py-8 px-8 md:px-16 lg:px-24 xl:px-32">
+    <div className="container mx-auto px-4 py-6 sm:px-6 md:px-16 md:py-8 lg:px-24 xl:px-32">
       {/* Hero Section */}
-      <section className="mb-16">
-        <div className="relative h-[500px] w-full overflow-hidden rounded-3xl shadow-card-hover md:h-[560px]">
+      <section className="mb-12 md:mb-16">
+        <div className="relative h-[440px] w-full overflow-hidden rounded-2xl shadow-card-hover sm:h-[500px] sm:rounded-3xl md:h-[560px]">
           <Image
             src="/images/hero-v1a.png"
             alt="A-OK Store"
@@ -100,24 +100,27 @@ export default async function Home() {
             className="object-cover object-center"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark/80 via-dark/30 to-dark/10" />
-          <div className="absolute inset-0 flex items-end justify-center pb-12 md:justify-start md:pb-16">
-            <div className="animate-fade-up px-6 text-center md:pl-14 md:text-left">
-              <p className="mb-3 text-sm font-bold uppercase tracking-[0.3em] text-bone/80">
+          <div className="absolute inset-0 flex items-end justify-center pb-6 sm:pb-12 md:justify-start md:pb-16">
+            <div className="w-full animate-fade-up px-5 text-center sm:w-auto sm:px-6 md:pl-14 md:text-left">
+              <p className="mb-2 text-xs font-bold uppercase tracking-[0.3em] text-bone/80 sm:mb-3 sm:text-sm">
                 Apes On Keys
               </p>
               <h1 className="font-bebas-neue text-6xl leading-none text-bone md:text-8xl">
                 A - O K
               </h1>
-              <p className="mt-3 max-w-md font-space-grotesk text-lg text-bone/90 md:text-xl">
+              <p className="mt-2 font-space-grotesk text-base text-bone/90 sm:mt-3 sm:text-lg md:max-w-md md:text-xl">
                 AI nerdwear for the terminally online.
               </p>
-              <div className="mt-8 flex flex-wrap items-center justify-center gap-3 md:justify-start">
-                <Link href="/products" className="btn btn-primary px-8 py-3 text-base">
+              <div className="mt-5 flex w-full flex-col items-stretch gap-3 sm:mt-8 sm:w-auto sm:flex-row sm:items-center sm:justify-center md:justify-start">
+                <Link
+                  href="/products"
+                  className="btn btn-primary w-full px-8 py-3 text-base sm:w-auto"
+                >
                   Shop Now
                 </Link>
                 <Link
                   href="/game"
-                  className="btn border-2 border-bone/80 bg-transparent px-8 py-3 text-base text-bone hover:bg-bone hover:text-charcoal-dark hover:-translate-y-0.5"
+                  className="btn w-full border-2 border-bone/80 bg-transparent px-8 py-3 text-base text-bone hover:bg-bone hover:text-charcoal-dark hover:-translate-y-0.5 sm:w-auto"
                 >
                   Play the Game
                 </Link>
@@ -128,7 +131,7 @@ export default async function Home() {
       </section>
 
       {/* Featured Products Section */}
-      <section className="mb-20">
+      <section className="mb-14 md:mb-20">
         <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
           <div>
             <span className="section-eyebrow">Fresh off the keys</span>
@@ -156,20 +159,20 @@ export default async function Home() {
             </svg>
           </Link>
         </div>
-        <div className="stagger-children grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="stagger-children grid grid-cols-2 gap-3 sm:gap-6 lg:grid-cols-3">
           {productsToShow.map((product) => (
             <ProductCard key={product.id} product={product} />
           ))}
         </div>
-        <div className="mt-10 text-center sm:hidden">
-          <Link href="/products" className="btn btn-outline">
+        <div className="mt-8 text-center sm:hidden">
+          <Link href="/products" className="btn btn-outline w-full">
             View All Products
           </Link>
         </div>
       </section>
 
       {/* About Section */}
-      <section className="mb-20">
+      <section className="mb-14 md:mb-20">
         <div className="mb-8 text-center">
           <span className="section-eyebrow">The lore</span>
           <h2 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import ImageGrid from "@/app/components/ImageGrid";
+import ProductCard from "@/app/components/product/ProductCard";
 import fs from "fs";
 import path from "path";
 
@@ -79,20 +80,18 @@ export default async function Home() {
   let productsToShow: Array<any> = [];
   try {
     productsToShow = await getFeaturedProductsData();
-    console.log(`Fetched ${productsToShow.length} featured products successfully`);
   } catch (error) {
     console.error("Error fetching featured products:", error);
   }
 
   // Get gallery images using the new function
   const galleryImages = await getGalleryImages();
-  const hasGalleryImages = galleryImages.length > 0;
 
   return (
     <div className="container mx-auto py-8 px-8 md:px-16 lg:px-24 xl:px-32">
       {/* Hero Section */}
-      <section className="mb-12">
-        <div className="relative h-[500px] w-full overflow-hidden rounded-lg">
+      <section className="mb-16">
+        <div className="relative h-[500px] w-full overflow-hidden rounded-3xl shadow-card-hover md:h-[560px]">
           <Image
             src="/images/hero-v1a.png"
             alt="A-OK Store"
@@ -100,20 +99,27 @@ export default async function Home() {
             priority
             className="object-cover object-center"
           />
-          <div className="absolute inset-0 bg-dark/50 flex items-center justify-center md:items-start md:justify-end md:pt-16">
-            <div
-              className="hero-content bg-white/80 p-4 rounded-xl md:mr-6 flex flex-col items-center text-center justify-center"
-              style={{ width: "auto", maxWidth: "280px" }}
-            >
-              <h1 className="text-6xl md:text-6xl font-bebas-neue text-dark leading-tight text-shadow-bold">
+          <div className="absolute inset-0 bg-gradient-to-t from-dark/80 via-dark/30 to-dark/10" />
+          <div className="absolute inset-0 flex items-end justify-center pb-12 md:justify-start md:pb-16">
+            <div className="animate-fade-up px-6 text-center md:pl-14 md:text-left">
+              <p className="mb-3 text-sm font-bold uppercase tracking-[0.3em] text-bone/80">
+                Apes On Keys
+              </p>
+              <h1 className="font-bebas-neue text-6xl leading-none text-bone md:text-8xl">
                 A - O K
               </h1>
-              <p className="text-lg md:text-xl text-dark font-bebas-neue tracking-wide">
-                APES ON KEYS - AI NERDWEAR
+              <p className="mt-3 max-w-md font-space-grotesk text-lg text-bone/90 md:text-xl">
+                AI nerdwear for the terminally online.
               </p>
-              <div className="mt-5">
-                <Link href="/products" className="btn btn-primary">
+              <div className="mt-8 flex flex-wrap items-center justify-center gap-3 md:justify-start">
+                <Link href="/products" className="btn btn-primary px-8 py-3 text-base">
                   Shop Now
+                </Link>
+                <Link
+                  href="/game"
+                  className="btn border-2 border-bone/80 bg-transparent px-8 py-3 text-base text-bone hover:bg-bone hover:text-charcoal-dark hover:-translate-y-0.5"
+                >
+                  Play the Game
                 </Link>
               </div>
             </div>
@@ -122,39 +128,40 @@ export default async function Home() {
       </section>
 
       {/* Featured Products Section */}
-      <section className="mb-12">
-        <h2 className="text-3xl font-bold mb-6">Featured Products</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {productsToShow.map((product) => (
-            <Link
-              href={`/products/${product.handle}`}
-              key={product.id}
-              className="group"
+      <section className="mb-20">
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <span className="section-eyebrow">Fresh off the keys</span>
+            <h2 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">
+              Featured Products
+            </h2>
+          </div>
+          <Link
+            href="/products"
+            className="group hidden items-center gap-1 text-sm font-semibold text-maroon transition-colors hover:text-maroon-dark sm:inline-flex"
+          >
+            View all
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1"
             >
-              <div className="border-2 border-[#1F1F1F] bg-[#F5F2DC] p-5 rounded-xl text-[#1F1F1F] transition-all duration-200 hover:shadow-lg hover:scale-[1.02] h-full">
-                <div className="relative aspect-square bg-light mb-4 rounded-lg overflow-hidden border border-[#1F1F1F]">
-                  <Image
-                    src={product.images.edges[0]?.node.url || "/product-placeholder.jpg"}
-                    alt={product.title}
-                    fill
-                    className="object-cover transition-transform duration-300 group-hover:scale-105 product-image-hover"
-                    unoptimized={!product.images.edges[0]?.node.url?.startsWith('http')}
-                  />
-                </div>
-                <h3 className="font-bebas-neue text-xl mb-1 tracking-wide">
-                  {product.title}
-                </h3>
-                <p className="text-[#8B1E24] font-bebas-neue text-lg mb-4">
-                  $
-                  {parseFloat(
-                    product.priceRange.minVariantPrice.amount
-                  ).toFixed(2)}
-                </p>
-              </div>
-            </Link>
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
+        <div className="stagger-children grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {productsToShow.map((product) => (
+            <ProductCard key={product.id} product={product} />
           ))}
         </div>
-        <div className="text-center mt-8">
+        <div className="mt-10 text-center sm:hidden">
           <Link href="/products" className="btn btn-outline">
             View All Products
           </Link>
@@ -162,31 +169,34 @@ export default async function Home() {
       </section>
 
       {/* About Section */}
-      <section className="mb-16">
-        <h1 className="text-4xl md:text-5xl font-bebas-neue mb-6 text-center">
-          Who are Apes On Keys?
-        </h1>
-        <div className="w-full max-w-3xl mx-auto bg-[#1E1E1E] rounded-lg overflow-hidden shadow-lg border border-gray-700">
-          <div className="flex items-center bg-[#333333] px-4 py-2 border-b border-gray-700">
+      <section className="mb-20">
+        <div className="mb-8 text-center">
+          <span className="section-eyebrow">The lore</span>
+          <h2 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">
+            Who are Apes On Keys?
+          </h2>
+        </div>
+        <div className="mx-auto w-full max-w-3xl overflow-hidden rounded-2xl border border-gray-700 bg-[#1E1E1E] shadow-card-hover">
+          <div className="flex items-center border-b border-gray-700 bg-[#333333] px-4 py-2">
             <div className="flex space-x-2">
-              <div className="w-3 h-3 rounded-full bg-red-500"></div>
-              <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
-              <div className="w-3 h-3 rounded-full bg-green-500"></div>
+              <div className="h-3 w-3 rounded-full bg-red-500"></div>
+              <div className="h-3 w-3 rounded-full bg-yellow-500"></div>
+              <div className="h-3 w-3 rounded-full bg-green-500"></div>
             </div>
-            <div className="ml-4 text-gray-300 text-sm font-mono">
+            <div className="ml-4 font-mono text-sm text-gray-300">
               monkey_theorem.md
             </div>
           </div>
           <div
-            className="p-6 h-[400px] overflow-y-auto font-mono text-sm text-gray-300 leading-relaxed"
+            className="h-[400px] overflow-y-auto p-6 font-mono text-sm leading-relaxed text-gray-300"
             style={{ scrollbarWidth: "thin", scrollbarColor: "#555 #1E1E1E" }}
           >
-            <div className="flex items-center mb-3 text-gray-400 text-xs">
+            <div className="mb-3 flex items-center text-xs text-gray-400">
               <span className="mr-2">commit 42a7f9e</span>
               <span>Updated October 2025</span>
             </div>
             <p className="mb-4">
-              <span className="text-red-500 font-bold">
+              <span className="font-bold text-red-500">
                 The E/ACC Monkey Theorem
               </span>{" "}
               states that if you give an infinite number of AI models an
@@ -195,12 +205,12 @@ export default async function Home() {
               Shakespeare&apos;s works, their various HBO adaptations, and at
               least 47 different AI-generated musicals where Hamlet raps.
             </p>
-            <div className="mb-4 border border-green-800 bg-green-900/20 rounded">
-              <div className="flex items-center px-2 py-1 bg-green-800/30 text-green-400 text-xs">
+            <div className="mb-4 rounded border border-green-800 bg-green-900/20">
+              <div className="flex items-center bg-green-800/30 px-2 py-1 text-xs text-green-400">
                 <span className="mr-1">+</span>{" "}
                 <span>Added in PR #238 (Oct 2025)</span>
               </div>
-              <p className="p-2 border-l-4 border-green-600">
+              <p className="border-l-4 border-green-600 p-2">
                 Since the Q3 2025 introduction of Anthropic&apos;s Claude Haiku
                 and OpenAI&apos;s GPT-5-mini, we&apos;ve observed a 300%
                 increase in AI-generated Shakespearean sonnets about blockchain
@@ -221,12 +231,12 @@ export default async function Home() {
                 events from the 16th century.
               </span>
             </p>
-            <div className="mb-4 border border-green-800 bg-green-900/20 rounded">
-              <div className="flex items-center px-2 py-1 bg-green-800/30 text-green-400 text-xs">
+            <div className="mb-4 rounded border border-green-800 bg-green-900/20">
+              <div className="flex items-center bg-green-800/30 px-2 py-1 text-xs text-green-400">
                 <span className="mr-1">+</span>{" "}
                 <span>Replaced in PR #238 (Oct 2025)</span>
               </div>
-              <p className="p-2 border-l-4 border-green-600">
+              <p className="border-l-4 border-green-600 p-2">
                 However, they&apos;ll also generate an infinite number of
                 hallucinated Shakespeare quotes about cryptocurrency, several
                 million images of the Bard wearing Supreme hoodies, and
@@ -246,12 +256,12 @@ export default async function Home() {
               even add citations to completely imaginary academic papers and
               insist they&apos;re being helpful while doing so.
             </p>
-            <div className="mb-4 border border-green-800 bg-green-900/20 rounded">
-              <div className="flex items-center px-2 py-1 bg-green-800/30 text-green-400 text-xs">
+            <div className="mb-4 rounded border border-green-800 bg-green-900/20">
+              <div className="flex items-center bg-green-800/30 px-2 py-1 text-xs text-green-400">
                 <span className="mr-1">+</span>{" "}
                 <span>Comment by @monkeydev (Nov 2025)</span>
               </div>
-              <p className="p-2 border-l-4 border-green-600 italic">
+              <p className="border-l-4 border-green-600 p-2 italic">
                 The November 2025 &quot;Citation Verification Protocol&quot; has
                 only made this worse. Now AIs create elaborate fake DOIs and
                 even generate QR codes linking to non-existent journal websites
@@ -264,17 +274,17 @@ export default async function Home() {
               Juliet – though it&apos;s probably tagged as &quot;not financial
               advice&quot; and ends with a prompt to like and subscribe.
             </p>
-            <p className="bg-gray-700/30 p-3 rounded border-l-4 border-gray-500 mb-4">
-              <span className="text-gray-400 italic">Note:</span> This theorem
+            <p className="mb-4 rounded border-l-4 border-gray-500 bg-gray-700/30 p-3">
+              <span className="italic text-gray-400">Note:</span> This theorem
               has been reviewed by approximately 2.7 million AI models, each
               claiming to have a knowledge cutoff date that makes them unable to
               verify their own existence.
             </p>
-            <div className="border border-blue-800 bg-blue-900/20 rounded">
-              <div className="flex items-center px-2 py-1 bg-blue-800/30 text-blue-400 text-xs">
+            <div className="rounded border border-blue-800 bg-blue-900/20">
+              <div className="flex items-center bg-blue-800/30 px-2 py-1 text-xs text-blue-400">
                 <span className="mr-1">i</span> <span>Updated Dec 2025</span>
               </div>
-              <p className="p-2 border-l-4 border-blue-600">
+              <p className="border-l-4 border-blue-600 p-2">
                 As of December 2025, this number has increased to 4.3 million
                 models, with several now claiming to have &quot;quantum
                 uncertainty&quot; about their training cutoff dates, existing in
@@ -288,22 +298,26 @@ export default async function Home() {
 
       {/* Chaos Monkeys Image Grid - only render if we have images */}
       <section className="mb-16">
-        <div className="flex justify-center w-full">
-          <Link href="/gallery" className="no-underline hover:no-underline">
-            <h2 className="text-4xl md:text-5xl font-bebas-neue mb-6 text-center relative group inline-flex items-center justify-center">
-              <span className="relative z-10">CHAOS MONKEYS AT WORK</span>
-              <span className="absolute inset-0 bg-gradient-to-r from-transparent via-yellow-300/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 z-0"></span>
-              <span className="inline-block ml-1 text-gray-400 opacity-0 group-hover:opacity-70 transition-opacity duration-300">
-                →
-              </span>
-            </h2>
+        <div className="mb-8 flex w-full justify-center">
+          <Link href="/gallery" className="group no-underline hover:no-underline">
+            <div className="text-center">
+              <span className="section-eyebrow">The gallery</span>
+              <h2 className="relative inline-flex items-center justify-center font-bebas-neue text-4xl tracking-wide md:text-5xl">
+                <span className="relative z-10 transition-colors duration-300 group-hover:text-maroon">
+                  CHAOS MONKEYS AT WORK
+                </span>
+                <span className="ml-2 inline-block -translate-x-1 text-maroon opacity-0 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100">
+                  →
+                </span>
+              </h2>
+            </div>
           </Link>
         </div>
         {galleryImages && galleryImages.length > 0 ? (
           <ImageGrid images={galleryImages} title="CHAOS MONKEYS AT WORK" />
         ) : (
-          <div className="text-center p-8 bg-gray-100 rounded-lg border border-gray-300">
-            <p className="text-gray-600">
+          <div className="rounded-2xl border border-dark/10 bg-secondary-light p-8 text-center">
+            <p className="text-dark-light">
               Image gallery is currently loading or unavailable.
             </p>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,10 +87,19 @@ export default async function Home() {
   // Get gallery images using the new function
   const galleryImages = await getGalleryImages();
 
+  const tickerItems = [
+    "APES ON KEYS",
+    "AI NERDWEAR (FOR REAL)",
+    "INFINITE MONKEYS · INFINITE MERCH",
+    "BEAT THE GAME → 25% OFF",
+    "SHIP IT · WEAR IT · PROMPT IT",
+  ];
+
   return (
-    <div className="container mx-auto px-4 py-6 sm:px-6 md:px-16 md:py-8 lg:px-24 xl:px-32">
-      {/* Hero Section */}
-      <section className="mb-12 md:mb-16">
+    <div className="overflow-x-clip">
+      <div className="container mx-auto px-4 pt-6 sm:px-6 md:px-16 md:pt-8 lg:px-24 xl:px-32">
+        {/* Hero Section */}
+        <section>
         <div className="relative h-[440px] w-full overflow-hidden rounded-2xl shadow-card-hover sm:h-[500px] sm:rounded-3xl md:h-[560px]">
           <Image
             src="/images/hero-v1a.png"
@@ -125,11 +134,46 @@ export default async function Home() {
                   Play the Game
                 </Link>
               </div>
+              <p className="mt-3 text-xs text-bone/70 sm:text-sm">
+                Win{" "}
+                <span className="font-semibold text-bone/90">
+                  Run, Human, Run!
+                </span>{" "}
+                and score 25% off your order.
+              </p>
             </div>
           </div>
         </div>
       </section>
+      </div>
 
+      {/* Brand ticker */}
+      <section
+        aria-hidden="true"
+        className="marquee my-10 border-y-4 border-maroon bg-charcoal-dark py-3 md:my-14 md:py-4"
+      >
+        <div className="marquee-track">
+          {[0, 1].map((copy) => (
+            <div
+              key={copy}
+              className="flex items-center"
+              aria-hidden={copy === 1}
+            >
+              {tickerItems.map((item) => (
+                <span
+                  key={item}
+                  className="flex items-center font-bebas-neue text-xl tracking-[0.15em] text-bone md:text-2xl"
+                >
+                  <span className="mx-5 md:mx-8">{item}</span>
+                  <span className="text-primary-light">✦</span>
+                </span>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 pb-6 sm:px-6 md:px-16 md:pb-8 lg:px-24 xl:px-32">
       {/* Featured Products Section */}
       <section className="mb-14 md:mb-20">
         <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
@@ -326,6 +370,7 @@ export default async function Home() {
           </div>
         )}
       </section>
+      </div>
     </div>
   );
 }

--- a/app/products/[handle]/ProductPageClient.tsx
+++ b/app/products/[handle]/ProductPageClient.tsx
@@ -239,8 +239,10 @@ export function ProductDetails({
   };
 
   return (
-    <div className="animate-fade-up">
-      <h1 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">
+    // No entrance animation here: a persistent transform would become the
+    // containing block for the fixed sticky add-to-cart bar rendered inside.
+    <div>
+      <h1 className="animate-fade-up font-bebas-neue text-4xl tracking-wide md:text-5xl">
         {product.title}
       </h1>
 

--- a/app/products/[handle]/ProductPageClient.tsx
+++ b/app/products/[handle]/ProductPageClient.tsx
@@ -306,6 +306,7 @@ export function ProductDetails({
           }}
           showSizeWarning={isClothingItem && hasSizeOptions && !selectedSize}
           showColorWarning={hasColorOptions && !selectedColor}
+          stickyOnMobile
         />
       </div>
 

--- a/app/products/[handle]/ProductPageClient.tsx
+++ b/app/products/[handle]/ProductPageClient.tsx
@@ -49,31 +49,39 @@ export function SizeSelector({
     onSizeSelect(size, variantId);
   };
 
-  const handleSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const size = e.target.value;
-    handleSizeSelection(size);
-  };
-
   return (
     <div className="mt-6">
-      <label htmlFor="size-select" className="block text-sm font-medium mb-2">
-        Size
-      </label>
-      <select
-        id="size-select"
-        value={selectedSize}
-        onChange={handleSizeChange}
-        className="w-full p-2 border border-secondary rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-primary"
-      >
-        <option value="" disabled>
-          Select a size
-        </option>
-        {sizes.map((size) => (
-          <option key={size} value={size}>
-            {size}
-          </option>
-        ))}
-      </select>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-semibold uppercase tracking-wider text-dark">
+          Size
+        </span>
+        {selectedSize && (
+          <span className="text-sm text-dark-light">
+            Selected: <span className="font-semibold">{selectedSize}</span>
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Size">
+        {sizes.map((size) => {
+          const isSelected = selectedSize === size;
+          return (
+            <button
+              key={size}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              onClick={() => handleSizeSelection(size)}
+              className={`min-w-[3rem] rounded-lg border-2 px-3 py-2 text-sm font-semibold transition-all duration-200 ease-out-expo active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-maroon focus-visible:ring-offset-2 ${
+                isSelected
+                  ? 'border-charcoal-dark bg-charcoal-dark text-bone shadow-sm'
+                  : 'border-dark/20 bg-white text-dark hover:border-charcoal-dark hover:-translate-y-0.5 hover:shadow-sm'
+              }`}
+            >
+              {size}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -151,25 +159,34 @@ export function ColorSelector({
 
   return (
     <div className="mt-6">
-      <h3 className="text-sm font-medium mb-2">Color</h3>
-      <div className="flex flex-wrap gap-2">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-semibold uppercase tracking-wider text-dark">
+          Color
+        </span>
+        {selectedColor && (
+          <span className="text-sm text-dark-light">
+            Selected: <span className="font-semibold">{selectedColor}</span>
+          </span>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-3">
         {colors.map((color) => (
           <button
             key={color}
             onClick={() => handleColorClick(color)}
-            className={`w-8 h-8 rounded-full border ${getColorStyle(color)} ${
+            className={`h-9 w-9 rounded-full border transition-all duration-200 ease-out-expo active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-maroon focus-visible:ring-offset-2 ${getColorStyle(
+              color
+            )} ${
               selectedColor === color
-                ? 'ring-2 ring-primary ring-offset-2'
-                : 'hover:ring-1 hover:ring-gray-300'
+                ? 'scale-110 ring-2 ring-maroon ring-offset-2'
+                : 'hover:scale-110 hover:ring-1 hover:ring-gray-300'
             }`}
             title={color}
             aria-label={`Select ${color} color`}
+            aria-pressed={selectedColor === color}
           />
         ))}
       </div>
-      {selectedColor && (
-        <p className="mt-2 text-sm text-gray-600">Selected: {selectedColor}</p>
-      )}
     </div>
   );
 }
@@ -222,11 +239,15 @@ export function ProductDetails({
   };
 
   return (
-    <div>
-      <h1 className="text-3xl font-bold">{product.title}</h1>
+    <div className="animate-fade-up">
+      <h1 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">
+        {product.title}
+      </h1>
 
-      <div className="mt-4">
-        <p className="text-2xl font-medium text-primary">${price.toFixed(2)}</p>
+      <div className="mt-3">
+        <p className="font-space-grotesk text-3xl font-medium text-maroon">
+          ${price.toFixed(2)}
+        </p>
       </div>
 
       {/* Color selector for products with color options */}
@@ -251,12 +272,14 @@ export function ProductDetails({
       {/* Variant selector for non-clothing items with multiple variants */}
       {!isClothingItem && !hasColorOptions && variants.length > 1 && (
         <div className="mt-6">
-          <h3 className="text-sm font-medium">Variants</h3>
+          <span className="text-sm font-semibold uppercase tracking-wider text-dark">
+            Variants
+          </span>
           <div className="mt-2 flex flex-wrap gap-2">
             {variants.map((variant) => (
               <button
                 key={variant.id}
-                className="rounded-md border border-secondary px-3 py-1 text-sm hover:bg-secondary-light"
+                className="rounded-lg border-2 border-dark/20 px-3 py-2 text-sm font-semibold transition-all duration-200 hover:border-charcoal-dark hover:-translate-y-0.5 hover:shadow-sm active:scale-95"
               >
                 {variant.title}
               </button>
@@ -266,7 +289,7 @@ export function ProductDetails({
       )}
 
       {/* Add to cart button for all products */}
-      <div className="mt-6">
+      <div className="mt-8">
         <AddToCartButton
           product={{
             id: product.id,
@@ -286,8 +309,10 @@ export function ProductDetails({
         />
       </div>
 
-      <div className="mt-8 prose prose-sm max-w-none prose-headings:font-medium prose-ul:list-disc prose-ul:pl-5 prose-li:mt-2 prose-p:mb-4">
-        <h3 className="text-lg font-medium">Description</h3>
+      <div className="mt-10 border-t border-dark/10 pt-8 prose prose-sm max-w-none prose-headings:font-medium prose-ul:list-disc prose-ul:pl-5 prose-li:mt-2 prose-p:mb-4">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-dark">
+          Description
+        </h3>
         <div
           dangerouslySetInnerHTML={{
             __html:
@@ -298,18 +323,20 @@ export function ProductDetails({
                     .replace(/\r/g, '')
                 : ''),
           }}
-          className="product-description"
+          className="product-description mt-3"
         />
       </div>
 
       {product.tags.length > 0 && (
         <div className="mt-6">
-          <h3 className="text-sm font-medium">Tags</h3>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-dark">
+            Tags
+          </h3>
           <div className="mt-2 flex flex-wrap gap-2">
             {product.tags.map((tag: string) => (
               <span
                 key={tag}
-                className="rounded-full bg-secondary px-3 py-1 text-xs"
+                className="rounded-full border border-dark/10 bg-secondary px-3 py-1 text-xs font-medium transition-colors duration-200 hover:bg-secondary-dark"
               >
                 {tag}
               </span>
@@ -350,15 +377,16 @@ export function ProductPageContent({
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
   return (
-    <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-12">
       {/* Product Images */}
-      <div className="space-y-4">
-        <div className="relative aspect-square overflow-hidden rounded-lg bg-secondary-light">
+      <div className="space-y-4 md:sticky md:top-24 md:self-start">
+        <div className="group relative aspect-square overflow-hidden rounded-2xl border border-dark/10 bg-secondary-light shadow-card">
           <Image
+            key={selectedImageIndex}
             src={images[selectedImageIndex]?.url || '/product-placeholder.jpg'}
             alt={images[selectedImageIndex]?.alt || product.title}
             fill
-            className="object-cover"
+            className="animate-fade-in object-cover transition-transform duration-500 ease-out-expo group-hover:scale-105"
             priority
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             unoptimized={!images[selectedImageIndex]?.url?.startsWith('http')}
@@ -366,12 +394,17 @@ export function ProductPageContent({
         </div>
 
         {images.length > 1 && (
-          <div className="grid grid-cols-4 gap-2">
+          <div className="grid grid-cols-4 gap-3">
             {images.map((image, index) => (
-              <div
+              <button
                 key={index}
-                className={`relative aspect-square overflow-hidden rounded-lg bg-secondary-light cursor-pointer ${
-                  selectedImageIndex === index ? 'ring-2 ring-primary' : ''
+                type="button"
+                aria-label={`View image ${index + 1} of ${product.title}`}
+                aria-pressed={selectedImageIndex === index}
+                className={`relative aspect-square overflow-hidden rounded-xl border-2 bg-secondary-light transition-all duration-200 ease-out-expo focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-maroon focus-visible:ring-offset-2 ${
+                  selectedImageIndex === index
+                    ? 'border-maroon shadow-sm'
+                    : 'border-transparent opacity-70 hover:-translate-y-0.5 hover:opacity-100 hover:shadow-sm'
                 }`}
                 onClick={() => setSelectedImageIndex(index)}
               >
@@ -383,7 +416,7 @@ export function ProductPageContent({
                   sizes="(max-width: 768px) 25vw, (max-width: 1200px) 20vw, 10vw"
                   unoptimized={!image.url?.startsWith('http')}
                 />
-              </div>
+              </button>
             ))}
           </div>
         )}

--- a/app/products/[handle]/page.tsx
+++ b/app/products/[handle]/page.tsx
@@ -286,7 +286,7 @@ export default async function ProductPage({
   console.log("Color options:", colorValues);
 
   return (
-    <div className="container py-8">
+    <div className="container py-10 md:py-14">
       <ProductPageContent
         product={product}
         images={images}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -61,7 +61,7 @@ export default async function ProductsPage({
         </div>
         <nav
           aria-label="Product categories"
-          className="mt-6 flex flex-wrap gap-2"
+          className="no-scrollbar -mx-4 mt-6 flex gap-2 overflow-x-auto px-4 pb-1 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0"
         >
           {categories.map(({ label, value }) => {
             const isActive = category === value || (!category && !value);
@@ -69,7 +69,7 @@ export default async function ProductsPage({
               <Link
                 key={label}
                 href={value ? `/products?category=${value}` : "/products"}
-                className={`chip ${isActive ? "chip-active" : ""}`}
+                className={`chip flex-shrink-0 whitespace-nowrap ${isActive ? "chip-active" : ""}`}
                 aria-current={isActive ? "page" : undefined}
               >
                 {label}
@@ -91,7 +91,7 @@ export default async function ProductsPage({
 
       <Suspense
         fallback={
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          <div className="grid grid-cols-2 gap-3 sm:gap-6 md:grid-cols-3 lg:grid-cols-4">
             {Array.from({ length: 8 }).map((_, i) => (
               <div
                 key={i}
@@ -118,7 +118,7 @@ export default async function ProductsPage({
             </Link>
           </div>
         ) : (
-          <div className="stagger-children grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          <div className="stagger-children grid grid-cols-2 gap-3 sm:gap-6 md:grid-cols-3 lg:grid-cols-4">
             {products.map((product) => (
               <ProductCard key={product.id} product={product} />
             ))}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,11 +1,17 @@
 import { Suspense } from "react";
 import Link from "next/link";
-import Image from "next/image";
 import { getAllProducts, getProductsByCategory, SimpleProduct as ShopifyProduct } from "@/app/lib/catalog";
 import ProductCard from "@/app/components/product/ProductCard";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0; // Disable caching for this page
+
+const categories = [
+  { label: "All", value: undefined },
+  { label: "T-Shirts", value: "t-shirts" },
+  { label: "Hoodies", value: "hoodies" },
+  { label: "Hats", value: "hats" },
+];
 
 export default async function ProductsPage({
   searchParams,
@@ -22,8 +28,6 @@ export default async function ProductsPage({
       : undefined;
 
   try {
-    console.log("Fetching products in page component...");
-    
     // Use category-specific API if category is provided
     if (category) {
       products = await getProductsByCategory(category);
@@ -42,12 +46,42 @@ export default async function ProductsPage({
   }
 
   return (
-    <div className="container py-8">
-      <h1 className="mb-8 text-3xl font-bold">{pageTitle}</h1>
+    <div className="container py-10 md:py-14">
+      <header className="mb-8 animate-fade-up">
+        <span className="section-eyebrow">A-OK Catalog</span>
+        <div className="flex flex-wrap items-baseline justify-between gap-4">
+          <h1 className="font-bebas-neue text-4xl tracking-wide md:text-5xl">
+            {pageTitle}
+          </h1>
+          {!error && products.length > 0 && (
+            <p className="text-sm text-dark-light">
+              {products.length} {products.length === 1 ? "item" : "items"}
+            </p>
+          )}
+        </div>
+        <nav
+          aria-label="Product categories"
+          className="mt-6 flex flex-wrap gap-2"
+        >
+          {categories.map(({ label, value }) => {
+            const isActive = category === value || (!category && !value);
+            return (
+              <Link
+                key={label}
+                href={value ? `/products?category=${value}` : "/products"}
+                className={`chip ${isActive ? "chip-active" : ""}`}
+                aria-current={isActive ? "page" : undefined}
+              >
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      </header>
 
       {error ? (
-        <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg p-4 mb-8">
-          <h2 className="text-lg font-semibold mb-2">Error loading products</h2>
+        <div className="mb-8 animate-fade-up rounded-2xl border border-red-200 bg-red-50 p-6 text-red-800">
+          <h2 className="mb-2 text-lg font-semibold">Error loading products</h2>
           <p>{error}</p>
           <p className="mt-2 text-sm">
             Please try again or contact support if the issue persists.
@@ -55,15 +89,36 @@ export default async function ProductsPage({
         </div>
       ) : null}
 
-      <Suspense fallback={<p>Loading products...</p>}>
+      <Suspense
+        fallback={
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="card animate-pulse"
+                aria-hidden="true"
+              >
+                <div className="aspect-square w-full bg-light-dark" />
+                <div className="space-y-2 p-4">
+                  <div className="h-4 w-3/4 rounded bg-light-dark" />
+                  <div className="h-5 w-1/4 rounded bg-light-dark" />
+                </div>
+              </div>
+            ))}
+          </div>
+        }
+      >
         {products.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-lg">
+          <div className="animate-fade-up rounded-2xl border border-dark/10 bg-secondary-light py-16 text-center">
+            <p className="text-lg font-medium">
               No products found matching your criteria.
             </p>
+            <Link href="/products" className="btn btn-primary mt-4">
+              View all products
+            </Link>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          <div className="stagger-children grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {products.map((product) => (
               <ProductCard key={product.id} product={product} />
             ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ module.exports = {
     extend: {
       fontFamily: {
         'bebas-neue': ['var(--font-bebas-neue)'],
+        'space-grotesk': ['var(--font-space-grotesk)', 'sans-serif'],
       },
       colors: {
         primary: {
@@ -29,7 +30,63 @@ module.exports = {
         light: {
           DEFAULT: '#FFFFFF', // white
           dark: '#F3F4F6',
-        }
+        },
+        maroon: {
+          DEFAULT: '#8B1E24', // brand deep red
+          dark: '#6E171C',
+        },
+        bone: {
+          DEFAULT: '#F5F2DC', // brand bone white
+          dark: '#E9E4C8',
+        },
+        charcoal: {
+          DEFAULT: '#2C2C2C',
+          dark: '#1F1F1F',
+        },
+      },
+      boxShadow: {
+        card: '0 1px 2px rgba(23, 23, 23, 0.06), 0 4px 12px rgba(23, 23, 23, 0.06)',
+        'card-hover':
+          '0 2px 4px rgba(23, 23, 23, 0.08), 0 12px 28px rgba(23, 23, 23, 0.14)',
+        drawer: '-8px 0 32px rgba(23, 23, 23, 0.18)',
+      },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+        'fade-up': {
+          from: { opacity: '0', transform: 'translateY(16px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
+        'scale-in': {
+          from: { opacity: '0', transform: 'scale(0.96)' },
+          to: { opacity: '1', transform: 'scale(1)' },
+        },
+        'slide-in-right': {
+          from: { transform: 'translateX(100%)' },
+          to: { transform: 'translateX(0)' },
+        },
+        'badge-pop': {
+          '0%': { transform: 'scale(0.4)' },
+          '60%': { transform: 'scale(1.25)' },
+          '100%': { transform: 'scale(1)' },
+        },
+        shimmer: {
+          from: { backgroundPosition: '200% 0' },
+          to: { backgroundPosition: '-200% 0' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 0.4s ease-out both',
+        'fade-up': 'fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'scale-in': 'scale-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'slide-in-right': 'slide-in-right 0.35s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'badge-pop': 'badge-pop 0.35s cubic-bezier(0.16, 1, 0.3, 1) both',
+        shimmer: 'shimmer 1.6s linear infinite',
+      },
+      transitionTimingFunction: {
+        'out-expo': 'cubic-bezier(0.16, 1, 0.3, 1)',
       },
     },
   },


### PR DESCRIPTION
## Summary

Refactors the storefront into a cohesive modern e-commerce design system built on the existing brand palette (maroon / bone / charcoal, Bebas Neue + Space Grotesk). No new packages — all Tailwind + CSS.

### Foundations
- Brand color tokens (`maroon`, `bone`, `charcoal`), card/drawer shadow scales, shared keyframes (fade-up, scale-in, slide-in-right, badge-pop, shimmer) with an out-expo easing curve
- Refined `.btn` variants (hover lift + active press), animated `.nav-link` underlines, `.chip` filters, `.card` primitives, staggered grid entrances
- `prefers-reduced-motion` support so all animations degrade gracefully

### Pages & components
- **ProductCard** — full Tailwind rewrite (no inline styles): hover lift, image zoom, product-type badge, slide-up "View Product" CTA
- **Products page** — eyebrow header, category filter chips with active state, item count, skeleton loading fallback, staggered card entrance
- **Home page** — gradient hero with staged entrance and dual CTAs; featured grid now reuses ProductCard for consistency; unified section headers
- **PDP** — size pill selector replaces the native `<select>`, animated image gallery with sticky column, polished color swatches and tag chips
- **Add to cart** — green "Added ✓" success-state animation; cart badge pops on count change
- **CartDrawer** — slide-in with blurred backdrop fade, Esc to close, refined item rows, checkout spinner state
- **Navbar/Footer** — animated underline links; dark footer with link slide and brand-colored social icon hovers

### Notes
- Legacy `.product-card` / `.size-button` CSS in `globals.css` is now unused but intentionally left in place (per repo rule: ask before deleting code). Can be removed in a follow-up.
- Bento grid and animated logo CSS untouched (still used by ImageGrid and the logo).

## Test plan
- `npm run lint` — passes (only pre-existing warnings in untouched files)
- `npm run build` — production build succeeds
- Review the Vercel preview deployment for visual QA: home, /products (+ category filters), a product detail page, and the cart drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZQudGBnWgzE3JuEYRsTVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZQudGBnWgzE3JuEYRsTVP)_